### PR TITLE
Add ACL for guests

### DIFF
--- a/middlewares/AccessMiddleware.php
+++ b/middlewares/AccessMiddleware.php
@@ -21,8 +21,15 @@ class AccessMiddleware extends ControllerBase implements MiddlewareInterface
         $controller = str_replace('Controller', '', $nameController);
         // get function
         $function = $arrHandler[1];
+        
         // check if controller is Index, if it´s Index, then checks if any of functions are called if so return allow
         if ($controller === 'Index') {
+            $allowed = 1;
+            return $allowed;
+        }
+
+        // check if exist a controllers and functions in ACL Guest, so return allow
+        if (array_key_exists($controller, $arrResources['Guest']) && in_array($function, $arrResources['Guest'][$controller])) {
             $allowed = 1;
             return $allowed;
         }


### PR DESCRIPTION
The guest role in AccessMiddleware.php is for users that doesn't have jwt token, because them are only allowed to use method on IndexController

EDITED**